### PR TITLE
Fix error message not shown bug

### DIFF
--- a/src/main/java/seedu/ibook/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/ibook/model/item/UniqueItemList.java
@@ -36,13 +36,6 @@ public class UniqueItemList extends UniqueList<Item> {
     }
 
     /**
-     * Checks if an item is present in the list.
-     */
-    public boolean hasItem(Item item) {
-        return getExisting(item) != null;
-    }
-
-    /**
      * Adds an item to the list.
      * If the item is already in the list, combine it with the existing one.
      */

--- a/src/main/java/seedu/ibook/model/product/Product.java
+++ b/src/main/java/seedu/ibook/model/product/Product.java
@@ -93,7 +93,7 @@ public class Product implements Distinguishable<Product> {
      * Returns true if the {@code Item} is in the current viewed list.
      */
     public boolean hasItem(Item i) {
-        return items.hasItem(i);
+        return items.contains(i);
     }
 
     /**


### PR DESCRIPTION
# Changes
- Previously, the error message is not shown when updating an `item` will cause duplicates in the list.
- The bug is fixed now
# Related Issues/ PRs
- #118 
